### PR TITLE
Remove old keys

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -5,8 +5,6 @@ schema_version = 1
 description = "Bash-language-server support"
 repository = "https://github.com/zed-extensions/bash"
 authors = ["d1y <chenhonzhou@gmail.com>"]
-themes = []
-languages = ["languages/bash"]
 
 [lib]
 kind = "Rust"


### PR DESCRIPTION
These old keys were causing the extension to fail to build:
- https://github.com/zed-industries/extensions/actions/runs/15116558109/job/42488620871

Without them it builds properly:
- https://github.com/zed-industries/extensions/actions/runs/15116693668/job/42489078617

See:
- https://github.com/zed-industries/extensions/pull/2574